### PR TITLE
Explicit content type

### DIFF
--- a/DDD.Functions/TitoSync.cs
+++ b/DDD.Functions/TitoSync.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Net.Http.Formatting;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using DDD.Core.Tito;
@@ -61,7 +62,11 @@ namespace DDD.Functions
         {
             var response = await http.GetAsync(titoUrl);
             response.EnsureSuccessStatusCode();
-            var content = await response.Content.ReadAsAsync<PaginatedTitoOrderResponse>();
+
+            var formatters = new MediaTypeFormatterCollection();
+            formatters.JsonFormatter.SupportedMediaTypes.Add(new MediaTypeHeaderValue("application/vnd.api+json"));
+            var content = await response.Content.ReadAsAsync<PaginatedTitoOrderResponse>(formatters);
+            
             return (content.Registrations, content.Meta.HasMoreItems, content.Meta.NextPage);
         }
     }


### PR DESCRIPTION
It was discovered that we need to add json formatter

Add application/vnd.api+json to MediaTypeFormatterCollection for JsonFormatter as the API returns the data with that content type.

Refer to aspnet/WebHooks#83