### PR TITLE
Fix tito payload object

### DIFF
--- a/DDD.Functions/TitoSync.cs
+++ b/DDD.Functions/TitoSync.cs
@@ -73,12 +73,16 @@ namespace DDD.Functions
 
     public class PaginatedTitoOrderResponse
     {
+        [JsonProperty("meta")]
         public Meta Meta { get; set; }
+        
+        [JsonProperty("data")]
         public Registration[] Registrations { get; set; }
     }
 
     public class Registration
     {
+        [JsonProperty("id")]
         public string Id { get; set; }
     }
 


### PR DESCRIPTION
Registration list comes back as an array called "data". Added [JsonProperty("data")] to try to recognise it as Registration object 