### PR TITLE
Handle tito response for foramtter and null exceptions

### DIFF
--- a/DDD.Functions/local.settings.json
+++ b/DDD.Functions/local.settings.json
@@ -30,9 +30,9 @@
     // TitoSync
     "TitoSyncSchedule": "* * * * *",
     "TitoTable": "Tito",
-    "TitoEventId": "dddperth2019",
+    "TitoEventId": "testevent",
     "TitoAccountId": "dddperth",
-    "StopSyncingTitoFrom": "2018-06-18T23:59:59+08:00",
+    "StopSyncingTitoFrom": "2019-06-18T23:59:59+08:00",
     // GetSubmissions
     "SubmissionsAvailableFrom": "2018-06-05T08:00:00+08:00",
     "SubmissionsAvailableTo": "2018-06-17T23:59:59+08:00",


### PR DESCRIPTION
Looks like tito API is not stable and fail randomly. We need to be check responses before parsing and formatting it. 
Added a check before reading more registrations and try/catch before reading the response to log any errors.