### PR TITLE
Makes ticketnumber optional when submitting votes

### DIFF
--- a/DDD.Functions.Extensions/VotingConfig.cs
+++ b/DDD.Functions.Extensions/VotingConfig.cs
@@ -4,12 +4,26 @@ using Microsoft.Azure.WebJobs.Host.Config;
 
 namespace DDD.Functions.Extensions
 {
+    public enum TicketNumberWhileVoting
+    {
+        None,
+        Required,
+        Optional
+    }
+
     public class VotingConfig : Attribute
     {
         [AppSetting(Default = "VotesConnectionString")]
         public string ConnectionString { get; set; }
         [AppSetting(Default = "VotingTable")]
         public string Table { get; set; }
+        [AppSetting(Default = "TicketNumberWhileVoting")]
+        public string TicketNumberWhileVoting { get; set; }
+
+        public TicketNumberWhileVoting TicketNumberWhileVotingValue =>
+            TicketNumberWhileVoting == null ?
+                Extensions.TicketNumberWhileVoting.None  :
+                (TicketNumberWhileVoting) Enum.Parse(typeof(TicketNumberWhileVoting), TicketNumberWhileVoting);
     }
 
     [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.ReturnValue)]

--- a/DDD.Functions/SubmitVote.cs
+++ b/DDD.Functions/SubmitVote.cs
@@ -65,14 +65,17 @@ namespace DDD.Functions
                 return new StatusCodeResult((int) HttpStatusCode.BadRequest);
             }
 
-            // Get tickets
-            var ticketsRepo = await tickets.GetRepositoryAsync();
-            var matchedTicket = await ticketsRepo.GetAsync(conference.ConferenceInstance, vote.TicketNumber.ToUpperInvariant());
-            // Only if you have a valid ticket
-            if (string.IsNullOrEmpty(vote.TicketNumber) || matchedTicket == null)
+            if (voting.TicketNumberWhileVotingValue == TicketNumberWhileVoting.Required)
             {
-                log.LogWarning("Attempt to submit to SubmitVote endpoint without a valid ticket. Ticket id sent was {ticketNumber}", vote.TicketNumber);
-                return new StatusCodeResult((int) HttpStatusCode.BadRequest);
+                // Get tickets
+                var ticketsRepo = await tickets.GetRepositoryAsync();
+                var matchedTicket = await ticketsRepo.GetAsync(conference.ConferenceInstance, vote.TicketNumber.ToUpperInvariant());
+                // Only if you have a valid ticket
+                if (string.IsNullOrEmpty(vote.TicketNumber) || matchedTicket == null)
+                {
+                    log.LogWarning("Attempt to submit to SubmitVote endpoint without a valid ticket. Ticket id sent was {ticketNumber}", vote.TicketNumber);
+                    return new StatusCodeResult((int) HttpStatusCode.BadRequest);
+                }
             }
 
             // Get submitted sessions
@@ -105,7 +108,7 @@ namespace DDD.Functions
 
             // Save vote
             log.LogInformation("Successfully received vote with Id {voteId}; persisting...", vote.Id);
-            var voteToPersist = new Vote(conference.ConferenceInstance, vote.Id, vote.SessionIds, vote.Indices, vote.TicketNumber.ToUpperInvariant(), ip, vote.VoterSessionId, vote.VotingStartTime, keyDates.Now);
+            var voteToPersist = new Vote(conference.ConferenceInstance, vote.Id, vote.SessionIds, vote.Indices, vote.TicketNumber?.ToUpperInvariant(), ip, vote.VoterSessionId, vote.VotingStartTime, keyDates.Now);
             await repo.CreateAsync(voteToPersist);
 
             return new StatusCodeResult((int) HttpStatusCode.NoContent);

--- a/DDD.Functions/local.settings.json
+++ b/DDD.Functions/local.settings.json
@@ -45,6 +45,7 @@
     "VotingTable": "Votes",
     "VotingAvailableFrom": "2018-06-05T08:00:00+08:00",
     "VotingAvailableTo": "2018-06-14T23:59:59+08:00",
+    "TicketNumberWhileVoting": "Required",
     "MinVotes": "6",
     "MaxVotes": "12",
     // App Insights

--- a/infrastructure/Deploy.ps1
+++ b/infrastructure/Deploy.ps1
@@ -28,6 +28,7 @@ Param (
   [string] [Parameter(Mandatory = $true)] $ConferenceInstance,
   [string] [Parameter(Mandatory = $true)] $VotingAvailableFrom,
   [string] [Parameter(Mandatory = $true)] $VotingAvailableTo,
+  [ValidateSet("None","Optional","Required")] [string] [Parameter(Mandatory = $true)] $TicketNumberWhileVoting,
   [string] [Parameter(Mandatory = $true)] $MinVotes,
   [string] [Parameter(Mandatory = $true)] $MaxVotes,
   [string] [Parameter(Mandatory = $true)] $StopSyncingSessionsFrom,
@@ -65,6 +66,7 @@ function Get-Parameters() {
     "conferenceInstance"                = $ConferenceInstance;
     "votingAvailableFrom"               = $VotingAvailableFrom;
     "votingAvailableTo"                 = $VotingAvailableTo;
+	"ticketNumberWhileVoting"			= $TicketNumberWhileVoting;
     "minVotes"                          = $MinVotes;
     "maxVotes"                          = $MaxVotes;
     "titoWebhookSecret"                 = $TitoWebhookSecret;

--- a/infrastructure/azuredeploy.json
+++ b/infrastructure/azuredeploy.json
@@ -71,6 +71,14 @@
         "votingAvailableTo": {
             "type": "string"
         },
+        "ticketNumberWhileVoting": {
+            "type": "string",
+            "allowedValues": [
+                "None",
+                "Optional",
+                "Required"
+            ]
+        },
         "minVotes": {
             "type": "string"
         },
@@ -218,6 +226,7 @@
                         "VotingTable": "[variables('votingTable')]",
                         "VotingAvailableFrom": "[parameters('votingAvailableFrom')]",
                         "VotingAvailableTo": "[parameters('votingAvailableTo')]",
+                        "TicketNumberWhileVoting": "[parameters('ticketNumberWhileVoting')]",
                         "TitoWebhookSecret": "[parameters('titoWebhookSecret')]",
                         "TitoWebhookDeDupeTable": "[variables('titoWebhookDeDupeTable')]",
                         "TitoWebhookOrderNotificationQueue": "[variables('titoWebhookOrderNotificationQueue')]",

--- a/infrastructure/local.private.template.json
+++ b/infrastructure/local.private.template.json
@@ -16,6 +16,7 @@
     "ConferenceInstance": "2018",
     "VotingAvailableFrom": "2018-06-05T08:00:00+08:00",
     "VotingAvailableTo": "2018-06-14T23:59:59+08:00",
+    "TicketNumberWhileVoting":  "", 
     "MinVotes": "6",
     "MaxVotes": "12",
     "StopSyncingSessionsFrom": "2018-06-14T23:59:59+08:00",


### PR DESCRIPTION
The front end webapp allows three options for supplying a ticket number when voting: `None`, `Optional`, and `Required`.

Currently the back end ignores this and expects a ticket number to be supplied when a vote is submitted.

This PR introduces configuration to toggle the correct behaviour in the `SubmitVote` function, along with associated plumbing in `Deploy.ps1` and `azuredeploy.json`