### PR TITLE
Add IsSingleVoteEligibleForPrizeDraw as an option for Prizes draw backend

### DIFF
--- a/DDD.Functions.Extensions/FeedbackConfig.cs
+++ b/DDD.Functions.Extensions/FeedbackConfig.cs
@@ -12,6 +12,8 @@ namespace DDD.Functions.Extensions
         public string SessionFeedbackTable { get; set; }
         [AppSetting(Default = "ConferenceFeedbackTable")]
         public string ConferenceFeedbackTable { get; set; }
+        [AppSetting(Default = "IsSingleVoteEligibleForPrizeDraw")]
+        public bool IsSingleVoteEligibleForPrizeDraw { get; set; }
     }
 
     [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.ReturnValue)]

--- a/DDD.Functions/local.settings.json
+++ b/DDD.Functions/local.settings.json
@@ -59,6 +59,7 @@
     "FeedbackConnectionString": "UseDevelopmentStorage=true",
     "SessionFeedbackTable": "SessionFeedback",
     "ConferenceFeedbackTable": "ConferenceFeedback",
+    "IsSingleVoteEligibleForPrizeDraw": "true",
     "MinNumSessionFeedbackForPrizeDraw": "4",
     "FeedbackAvailableFrom": "2018-08-03T08:00:00+08:00",
     "FeedbackAvailableTo": "2019-08-03T05:00:00+08:00"

--- a/infrastructure/Deploy.ps1
+++ b/infrastructure/Deploy.ps1
@@ -42,6 +42,7 @@ Param (
   [string] [Parameter(Mandatory = $true)] $StopSyncingAppInsightsFrom,
   [string] [Parameter(Mandatory = $true)] $StopSyncingAgendaFrom,
   [string] [Parameter(Mandatory = $true)] $SessionizeAgendaApiKey,
+  [string] [Parameter(Mandatory = $true)] $IsSingleVoteEligibleForPrizeDraw,
   [string] [Parameter(Mandatory = $true)] $FeedbackAvailableFrom,
   [string] [Parameter(Mandatory = $true)] $FeedbackAvailableTo,
   [string] $ResourceGroupName = "$ConferenceName-backend-$AppEnvironment"
@@ -66,7 +67,7 @@ function Get-Parameters() {
     "conferenceInstance"                = $ConferenceInstance;
     "votingAvailableFrom"               = $VotingAvailableFrom;
     "votingAvailableTo"                 = $VotingAvailableTo;
-	"ticketNumberWhileVoting"			= $TicketNumberWhileVoting;
+    "ticketNumberWhileVoting"           = $TicketNumberWhileVoting;
     "minVotes"                          = $MinVotes;
     "maxVotes"                          = $MaxVotes;
     "titoWebhookSecret"                 = $TitoWebhookSecret;
@@ -79,6 +80,7 @@ function Get-Parameters() {
     "stopSyncingAppInsightsFrom"        = $StopSyncingAppInsightsFrom;
     "stopSyncingAgendaFrom"             = $StopSyncingAgendaFrom;
     "sessionizeAgendaApiKey"            = $SessionizeAgendaApiKey;
+    "isSingleVoteEligibleForPrizeDraw"  = $IsSingleVoteEligibleForPrizeDraw
     "feedbackAvailableFrom"             = $FeedbackAvailableFrom;
     "feedbackAvailableTo"               = $FeedbackAvailableTo;
   }

--- a/infrastructure/azuredeploy.json
+++ b/infrastructure/azuredeploy.json
@@ -115,6 +115,9 @@
         "sessionizeAgendaApiKey": {
             "type": "string"
         },
+        "isSingleVoteEligibleForPrizeDraw": {
+            "type": "string"
+        },
         "feedbackAvailableFrom": {
             "type": "string"
         },
@@ -257,6 +260,7 @@
                         "SessionFeedbackTable": "[variables('sessionFeedbackTable')]",
                         "ConferenceFeedbackTable": "[variables('conferenceFeedbackTable')]",
                         "MinNumSessionFeedbackForPrizeDraw": "[variables('minNumSessionFeedbackForPrizeDraw')]",
+                        "IsSingleVoteEligibleForPrizeDraw": "[parameters('isSingleVoteEligibleForPrizeDraw')]",
                         "FeedbackAvailableFrom": "[parameters('feedbackAvailableFrom')]",
                         "FeedbackAvailableTo": "[parameters('feedbackAvailableTo')]"
                     }

--- a/infrastructure/local.private.template.json
+++ b/infrastructure/local.private.template.json
@@ -30,6 +30,7 @@
     "StopSyncingAppInsightsFrom": "2018-06-14T23:59:59+08:00",
     "StopSyncingAgendaFrom": "2018-08-05T00:00:00+08:00",
     "SessionizeAgendaApiKey": "",
+    "IsSingleVoteEligibleForPrizeDraw": "true",
     "FeedbackAvailableFrom": "2018-06-05T08:00:00+08:00",
     "FeedbackAvailableTo": "2018-07-05T23:59:59+08:00"
 }


### PR DESCRIPTION
Add IsSingleVoteEligibleForPrizeDraw as a flag for Prizes draw backend.
This will allow anyone who submitted only one feedback (whatever it is conference or session feedback) to be part of the prizes draw