### PR TITLE
Added check to be able to disable the elo vote timeout if we desire.

### DIFF
--- a/DDD.Functions/EloVotingSubmitPair.cs
+++ b/DDD.Functions/EloVotingSubmitPair.cs
@@ -67,14 +67,18 @@ namespace DDD.Functions
                 return new StatusCodeResult((int)HttpStatusCode.BadRequest);
             }
 
-            // pick one or the other from (winnerInUnixTimeSeconds and loserInUnixTimeSeconds), we've already made sure that they match
-            var voteTime = DateTimeOffset.FromUnixTimeSeconds(winnerInUnixTimeSeconds);
-            var secondsSinceVote = (keyDates.Now - voteTime).TotalSeconds;
-            // make sure the submission is not more 5 minutes form the retrieveing these pair
-            if (eloVoting.EloAllowedTimeInSecondsToSubmit < secondsSinceVote)
+            // only bother doing this check if the configuration has the value set to greater than 0, otherwise consider it disabled.
+            if(eloVoting.EloAllowedTimeInSecondsToSubmit > 0) 
             {
-                log.LogWarning("Attempt to submit to EloVotingSubmitPair endpoint after {secondsSinceVote} seconds and the maximum allowed is {eloVoting.EloAllowedTimeInSecondsToSubmit} seconds (EloPair was retrived at {voteTime} ).", secondsSinceVote, eloVoting.EloAllowedTimeInSecondsToSubmit, voteTime);
-                return new StatusCodeResult((int)HttpStatusCode.BadRequest);
+                // pick one or the other from (winnerInUnixTimeSeconds and loserInUnixTimeSeconds), we've already made sure that they match
+                var voteTime = DateTimeOffset.FromUnixTimeSeconds(winnerInUnixTimeSeconds);
+                var secondsSinceVote = (keyDates.Now - voteTime).TotalSeconds;
+                // make sure the submission is not more 5 minutes form the retrieveing these pair
+                if (eloVoting.EloAllowedTimeInSecondsToSubmit < secondsSinceVote)
+                {
+                    log.LogWarning("Attempt to submit to EloVotingSubmitPair endpoint after {secondsSinceVote} seconds and the maximum allowed is {eloVoting.EloAllowedTimeInSecondsToSubmit} seconds (EloPair was retrived at {voteTime} ).", secondsSinceVote, eloVoting.EloAllowedTimeInSecondsToSubmit, voteTime);
+                    return new StatusCodeResult((int)HttpStatusCode.BadRequest);
+                }
             }
 
             // Valid session ids


### PR DESCRIPTION
The elo timeout check will not be made if the timeout is set to a number that is greater than zero, allowing the check to be configured through the application settings.