### PR TITLE
Omit keynotes from ELO vote

### DIFF
--- a/DDD.Functions/EloVotingGetPair.cs
+++ b/DDD.Functions/EloVotingGetPair.cs
@@ -17,6 +17,11 @@ namespace DDD.Functions
     {
         private static readonly Random Random = new Random();
 
+        private static readonly string[] KeynoteExternalIds = new[]
+        {
+            "337380"
+        };
+
         [FunctionName("EloVotingGetPair")]
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = null)]
@@ -64,6 +69,8 @@ namespace DDD.Functions
                 // we need to filter out "Keynote" from voting, which means we need to deserialize them all first
                 .Select(x => x.GetSession())
                 .Where(x => x.Format != "Keynote")
+                // this is a back-up in case the format mapping doesn't work
+                .Where(x => !KeynoteExternalIds.Contains(x.ExternalId))
                 // limiting it to two items ensures that we don't get any duplicates
                 .Take(2)
                 .Select(s => new Submission

--- a/DDD.Functions/EloVotingGetPair.cs
+++ b/DDD.Functions/EloVotingGetPair.cs
@@ -61,9 +61,11 @@ namespace DDD.Functions
                 .Where(x => x.Session != null)
                 // ordering by a guid is the same as effectively randomising the selection
                 .OrderBy(x => Guid.NewGuid())
-                // limiting it to two items ensures that we don't get any duplicates and we don't waste time deserializing more objects than required                
-                .Take(2)
+                // we need to filter out "Keynote" from voting, which means we need to deserialize them all first
                 .Select(x => x.GetSession())
+                .Where(x => x.Format != "Keynote")
+                // limiting it to two items ensures that we don't get any duplicates
+                .Take(2)
                 .Select(s => new Submission
                 {
                     Id = s.Id.ToString(),


### PR DESCRIPTION
I haven't set this up and tested it locally, so I'd appreciate someone else having a look at it. 

I spent about 20 minutes clicking "Draw" in the front-end looking for a keynote to verify that `s.Format != "Keynote"` would actually get it, but they never came up and I don't have sufficient access in Azure to check the data itself.