### PR TITLE
This setting keeps getting re-enabled when the functions reboot and i…

### DIFF
--- a/infrastructure/Deploy.ps1
+++ b/infrastructure/Deploy.ps1
@@ -35,6 +35,7 @@ Param (
   [string] [Parameter(Mandatory = $true)] $FeedbackAvailableFrom,
   [string] [Parameter(Mandatory = $true)] $FeedbackAvailableTo,
   [string] [Parameter(Mandatory = $true)] $EloPasswordPhrase,
+  [string] [Parameter(Mandatory = $true)] $EloAllowedTimeInSecondsToSubmit,  
   [string] $ResourceGroupName = "$ConferenceName-backend-$AppEnvironment"
 )
 
@@ -75,6 +76,7 @@ function Get-Parameters() {
     "feedbackAvailableFrom"             = $FeedbackAvailableFrom;
     "feedbackAvailableTo"               = $FeedbackAvailableTo;
     "eloPasswordPhrase"                 = $EloPasswordPhrase;
+    "eloAllowedTimeInSecondsToSubmit"   = $EloAllowedTimeInSecondsToSubmit;
     "eloUserSessionStoreAccountName"                = "$($ConferenceName)data$AppEnvironment".ToLower();
     "eloUserSessionStoreDatabaseName"               = "$($ConferenceName)data$AppEnvironment".ToLower();
     "eloUserSessionStoreContainerName"              = "$($ConferenceName)-$AppEnvironment-sessions".ToLower();


### PR DESCRIPTION
…s limiting the number of votes we can receive, so updating the deployment pipelines to set it to zero so it is disabled.